### PR TITLE
Requirement 3: Support newline character as alternate delimiter

### DIFF
--- a/calculate/calculate_test.go
+++ b/calculate/calculate_test.go
@@ -15,6 +15,36 @@ func TestAdd(t *testing.T) {
 		expectedErr bool
 	}{
 		{
+			name:        "newline delimiter",
+			input:       "1\n2",
+			expected:    decimal.NewFromInt(3),
+			expectedErr: false,
+		},
+		{
+			name:        "mixed delimiters",
+			input:       "1\n2,3",
+			expected:    decimal.NewFromInt(6),
+			expectedErr: false,
+		},
+		{
+			name:        "newline with whitespace",
+			input:       " 1 \n 2 ",
+			expected:    decimal.NewFromInt(3),
+			expectedErr: false,
+		},
+		{
+			name:        "multiple newlines",
+			input:       "1\n\n2",
+			expected:    decimal.NewFromInt(3),
+			expectedErr: false,
+		},
+		{
+			name:        "newline with empty lines",
+			input:       "1\n\n2\n",
+			expected:    decimal.NewFromInt(3),
+			expectedErr: false,
+		},
+		{
 			name:        "simple addition",
 			input:       "1,2",
 			expected:    decimal.NewFromInt(3),

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"challenge-calculator/calculate"
 	"challenge-calculator/logger"
+	"challenge-calculator/validate"
 )
 
 var logLevel = flag.String("log", "info", "Set the log level (debug, info, error)")
@@ -21,8 +22,9 @@ func main() {
 
 	for scanner.Scan() {
 		input := scanner.Text()
+		unescapedInput := validate.UnescapeNewline(input)
 
-		result, err := calculate.Add(input)
+		result, err := calculate.Add(unescapedInput)
 		if err != nil {
 			logger.UserMsg(fmt.Sprintf("Error calculating result: %v", err))
 			os.Exit(1)

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"challenge-calculator/logger"
@@ -9,10 +10,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-const (
-	inputDelimiter = ","
-	maxNumbers     = 2
-)
+var inputDelimiter = []rune{',', '\n'}
 
 func SanitizeInput(input string) ([]decimal.Decimal, error) {
 	logger.Debug(fmt.Sprintf("Starting input sanitization: %s", input))
@@ -36,7 +34,9 @@ func SanitizeInput(input string) ([]decimal.Decimal, error) {
 
 func splitInput(input string) []string {
 	trimmedInput := strings.TrimSpace(input)
-	parts := strings.Split(trimmedInput, inputDelimiter)
+	parts := strings.FieldsFunc(trimmedInput, func(r rune) bool {
+		return slices.Contains(inputDelimiter, r)
+	})
 
 	// Trim whitespace from each part
 	for i, part := range parts {
@@ -57,4 +57,8 @@ func parseDecimal(val string) decimal.Decimal {
 		return decimal.Zero
 	}
 	return number
+}
+
+func UnescapeNewline(input string) string {
+	return strings.ReplaceAll(input, "\\n", "\n")
 }


### PR DESCRIPTION
Support a newline character as an alternative delimiter e.g. 1\n2,3 will return 6.